### PR TITLE
Temporaly remove automated bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,35 +12,73 @@ Most of the settings and programs are managed with [home-manager](https://github
 > My daily machine is a Mac, and this requires some special attention to some settings that could not be managed with Nix and home-manager directly.
 
 
-## Installation
+## Installation on macOS
 
-```sh
-sh <(curl -L https://raw.githubusercontent.com/biosan/dotfiles/master/bootstrap.sh)
-```
-
-> **NOTE:**
-> 
-> The script will install my Macbook configuration by default.
-> To modify it download it first then edit the first lines, then execute it.
-
-This script will:
+1. Install XCode CLI tools
+    ```
+    xcode-select --install
+    ```
 
 1. Install Nix
+    ```
+    sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
+    ```
+1. Add home-manager and unstable channels
+    ```
+    nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+    nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs-unstable
+    nix-channel --update
+    export NIX_PATH=$HOME/.nix-defexpr/channels${NIX_PATH:+:}$NIX_PATH
+    ```
 1. Install home-manager
+    ```
+    nix-shell '<home-manager>' -A install
+    ```
 1. Clone this repo inside `~/.config/nixpkgs`
+    ```
+    git clone https://github.com/biosan/dotfiles ~/.config/nixpkgs
+    ```
 1. Setup home-manager configuration (install and configure programs)
-1. If on macOS:
-    1. Install Homebrew
-    1. Install apps from Homebrew
-    1. Setup some macOS-specific configuration
+    ```
+    home-manager switch
+    ```
+
+1. Install Homebrew
+    ```
+    bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    ```
+1. Install apps from Homebrew
+    ```
+    brew bundle --file ~/.config/nixpkgs/config/macos
+    ```
+1. Setup some macOS-specific configuration
+    ```
+    sh "~/.config/nixpkgs/config/macos/settings.sh"
+    ```
 
 
 ### Post installation steps
 
+1. Import GPG public keys
+    ```
+    curl https://keybase.io/biosan/key.asc | gpg --import
+    ```
+1. Insert YubiKey and import GPG secret key stubs
+    ```
+    gpg --card-status
+    ```
+1. Change dotfiles remote from HTTPS to SSH
+    ```
+    cd ~/.config/nixpkgs
+    git remote set-url origin git@github.com:biosan/dotfiles.git
+    ```
 1. Clone `pass` repository using SSH
+    ```
+    git clone <REPO_URL> ${PASSWORD_STORE_DIR}
+    ```
 
 
-#### macOS
+#### Other macOS stuff
 
 1. Install profile files for mail, DNS, VPN, etc.
 1. Login into
@@ -50,7 +88,7 @@ This script will:
     - Todoist
     - OmniFocus
 1. Enable Night Shift
-1. Verify Alfred license
+1. Insert Alfred license
 1. Organize menu bar items with Dozer
 
 
@@ -63,16 +101,16 @@ This script will:
 - [ ] Homebrew token in private `.envrc` file
 - [ ] Auto install profiles for mail, dns, vpn, etc. with `profiles -I -F "<PATH>"`
 - [ ] Enable *Night Shift*
-- [ ] Trust GPG keys
+- [ ] Import and trust GPG keys
 - [ ] Enable snap-to-grid for icons on the desktop and in other icon views
 - [ ] Configure Dozer
 - [ ] Configure Amethyst
 
 ### Things to setup declaratevely with Nix/Home-Manager
 
+- [ ] macOS configuration/settings/profiles (using [nix-darwin](https://github.com/LnL7/nix-darwin))
+- [ ] Switch to [flakes](https://nixos.wiki/wiki/Flakes) to improve reproducibility and UX
+- [ ] Complete system-in-a-container (even a VM will be fine) with full NixOS (ISO, cloud image, docker container)
 - [ ] Import and trust GPG keys
 - [ ] Clone `pass` repo
-- [ ] macOS configuration/settings/profiles (using [nix-darwin](https://github.com/LnL7/nix-darwin))
-- [ ] Maybe use [flakes](https://nixos.wiki/wiki/Flakes) to improve reproducibility
-- [ ] Complete system-in-a-container (even a VM will be fine) with full NixOS
 

--- a/config/macos/settings.sh
+++ b/config/macos/settings.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env sh
 
-HOSTNAME="biosanMBPr"
-GPG_KEY_FINGERPRINT=""
-PASS_GIT_URL=""
-ALFRED_PREF_FOLDER=""
-
 #######################################################
 ## This is a configuration script.                   ##
 ## Make attention! It can mess your macOS installion ##
@@ -21,9 +16,6 @@ read TEMP
 #############
 ## Generic ##
 #############
-
-# Set hostname
-m hostname "$HOSTNAME"
 
 # Disable boot sound effects
 #nvram SystemAudioVolume=" "
@@ -131,54 +123,6 @@ defaults write com.apple.ActivityMonitor ShowCategory -int 0
 # Privacy: don’t send search queries to Apple
 defaults write com.apple.Safari UniversalSearchEnabled -bool false
 defaults write com.apple.Safari SuppressSearchSuggestions -bool true
-
-
-###############
-## CLI Tools ##
-###############
-
-### GPG ###
-# Import my GPG public key from Keybase
-# NOTE: old "less secure" method: gpg --recv-keys "$GPG_KEY_FINGERPRINT"
-curl https://keybase.io/biosan/key.asc | gpg --import
-# Import my GPG key stubs from the smartcard
-echo "Importing private key stubs from the smartcard"
-echo "Insert the smartcard. Press any key to continue... (Ctrl-C to cancel)"
-read TMP
-gpg --card-status
-# Set your key as ultemately trusted
-#gpg --import-ownertrust <(echo "$GPG_KEY_FINGERPRINT:6:")
-export SSH_AUTH_SOCK=~/.gnupg/S.gpg-agent.ssh # Temporary export to clone Pass repo
-
-### Pass ###
-# Clone my password store repository
-echo "Setting up your password store repository"
-if [ -d ~/.password-store ]; then
-    echo "A .password-store folder is already inside your home directory"
-else
-    echo "Cloning repository using SSH"
-    echo "Insert the smartcard. Press any key to continue... (Ctrl-C to cancel)"
-    read TMP
-    git clone "$PASS_GIT_URL" ~/.password-store
-fi
-
-
-##########
-## Apps ##
-##########
-
-### Karabiner/Karabiner-Elements
-# Restart Karabiner-Elements to load new configuration file
-launchctl kickstart -k "gui/$(id -u)/org.pqrs.karabiner.karabiner_console_user_server"
-
-### Dropbox
-# Link notes stored in Dropbox to my home folder
-ln -sf ~/Dropbox/Notes ~/Notes
-ln -sf ~/Dropbox/Uni ~/Uni
-
-### Alfred2
-# Set Alfred sync folder
-defaults write com.runningwithcrayons.Alfred-Preferences syncfolder -string "$ALFRED_PREF_FOLDER"
 
 
 #############


### PR DESCRIPTION
Due to script reliability problems the installation steps to manually setup my Macbook are outlined in the README.

Hopefully after integration with `nix-darwin` and flakes will be easier to setup everything ***automagically** ™️*.

Also fix/add information on the README that is not related to the installation.